### PR TITLE
Fix: correctly extract filenames containing dots

### DIFF
--- a/src/htrflow/volume/volume.py
+++ b/src/htrflow/volume/volume.py
@@ -178,7 +178,7 @@ class PageNode(ImageNode):
 
     def __init__(self, image_path: str):
         self.path = image_path
-        label = os.path.basename(image_path).split(".")[0]
+        label = os.path.splitext(os.path.basename(image_path))[0]
         image = imgproc.read(self.path)
         self.original_shape = image.shape[:2]
         self.ratio = 1


### PR DESCRIPTION
## Fix Description
This fix ensures that filenames with dots are correctly extracted without truncating them at the first dot.

## Issue
Previously, the label was extracted using `split(".")[0]`, which removed everything after the first dot. This caused incorrect labels for filenames like `NL-HaNA_8.05.01_45_0077.jpg`.

## Solution
Changed `split(".")[0]` to `os.path.splitext(os.path.basename(image_path))[0]`, which correctly removes only the last file extension while keeping dots in the filename.